### PR TITLE
Fix dash delimited tags

### DIFF
--- a/timew.fish
+++ b/timew.fish
@@ -8,7 +8,7 @@ function __fish_timew_get_commands
 end
 
 function __fish_timew_get_tags
-    timew tags | tail -n+4 | cut -d'-' -f1 | awk '!/^[[:space:]]*$/' | awk '{$1=$1};1' | awk '{ print "\'"$0"\'"}'
+    timew tags | tail -n+4 | awk '{sub(/-([^-]*)$/, "\\1"); print}' | awk '!/^[[:space:]]*$/' | awk '{$1=$1};1' | awk '{ print "\'"$0"\'"}'
 end
 
 function __fish_timew_get_ids


### PR DESCRIPTION
This removes `cut` and replaces it with `awk` to remove the trailing dash from the tag output.