### PR TITLE
Fix tag completion

### DIFF
--- a/timew.fish
+++ b/timew.fish
@@ -8,7 +8,7 @@ function __fish_timew_get_commands
 end
 
 function __fish_timew_get_tags
-    timew tags | tail -n+4 | awk '{sub(/-([^-]*)$/, "\\1"); print}' | awk '!/^[[:space:]]*$/' | awk '{$1=$1};1' | awk '{ print "\'"$0"\'"}'
+    timew tags | tail -n+4 | awk '{ sub(/-$/, ""); print }' | awk '!/^[[:space:]]*$/' | awk '{$1=$1};1' | awk '{ print "\'"$0"\'"}'
 end
 
 function __fish_timew_get_ids


### PR DESCRIPTION
This change fixes an awk command so that it only removes the trailing hyphen, without adding any extraneous characters.

Should resolve https://github.com/GothenburgBitFactory/timewarrior/issues/575.